### PR TITLE
Test & refactor message handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const httpPort = 3838;
 const Discord = require('discord.js');
 
 const github = require('./src/github_api');
+const messageHandler = require('./src/message_handler')(github);
 const validate = require('./src/validate');
 
 const discordToken = process.env.DISCORD_API_TOKEN;
@@ -18,40 +19,7 @@ client.on('ready', () => {
   console.log("I'm up!");
 });
 
-client.on('message', message => {
-  if (message.author.bot) return;
-
-  const messageTokens = message.content.toLowerCase().split(/ +/);
-  const orgName = 'tory-toolkit';
-
-  if (!messageTokens[0] === 'orgbot') return;
-
-  const command = messageTokens[1];
-  const user = messageTokens[2];
-
-  if (command === 'check') {
-    if (messageTokens.length === 3) {
-      github.checkMembership(orgName, user, resp => {
-        message.reply(resp);
-      });
-    } else {
-      message.reply(`Invalid command. Try
-      \`orgbot check USERNAME \` -- check if GitHub user USERNAME is a member of the organisation`);
-    }
-  }
-
-  if (command === 'invite') {
-    if (messageTokens.length === 3) {
-      github.inviteMember(orgName, user, resp => {
-        message.reply(resp);
-      });
-    } else {
-      message.reply(`Invalid command. Try
-      \`orgbot invite USERNAME\` -- invite GitHub user USERNAME to the organisation`);
-    }
-  }
-
-});
+client.on('message', messageHandler.handleMessage);
 
 client.on('error', err => {
   console.log(err);

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -9,34 +9,36 @@ class MessageHandler {
     const messageTokens = message.content.toLowerCase().split(/ +/);
     const orgName = 'tory-toolkit';
 
-    if (!messageTokens[0] === 'orgbot') return;
+    if (messageTokens[0] !== 'orgbot') return;
 
     const command = messageTokens[1];
     const user = messageTokens[2];
 
-    if (command === 'check') {
-      if (messageTokens.length === 3) {
-        this.github.checkMembership(orgName, user, resp => {
-          message.reply(resp);
-        });
-      } else {
-        message.reply(`Invalid command. Try
-        \`orgbot check USERNAME \` -- check if GitHub user USERNAME is a member of the organisation`);
+    const isRecognisedCommand = ['check', 'invite'].includes(command);
+    if (isRecognisedCommand) {
+      if (command === 'check') {
+        if (messageTokens.length === 3) {
+          this.github.checkMembership(orgName, user, resp => {
+            message.reply(resp);
+          });
+        } else {
+          message.reply('Invalid use of `orgbot check`. Try `orgbot check <YOUR_GITHUB_USERNAME>` instead.');
+        }
       }
-    }
 
-    if (command === 'invite') {
-      if (messageTokens.length === 3) {
-        this.github.inviteMember(orgName, user, resp => {
-          message.reply(resp);
-        });
-      } else {
-        message.reply(`Invalid command. Try
-        \`orgbot invite USERNAME\` -- invite GitHub user USERNAME to the organisation`);
+      if (command === 'invite') {
+        if (messageTokens.length === 3) {
+          this.github.inviteMember(orgName, user, resp => {
+            message.reply(resp);
+          });
+        } else {
+          message.reply('Invalid use of `orgbot invite`. Try `orgbot invite <YOUR_GITHUB_USERNAME>` instead.');
+        }
       }
+    } else {
+      message.reply(`I don't understand the command \`${command}\`.`)
     }
   }
-
 }
 
 module.exports = MessageHandler;

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,43 +1,78 @@
+const GITHUB_ORG_NAME = 'tory-toolkit';
+const BOT_NAME = 'orgbot';
+
+/// The command executed on `orgbot invite <user>`
+class InviteUserCommand {
+  constructor(github) {
+    this.name = 'invite';
+    this.github = github;
+  }
+
+  run(user, responseHandler) {
+    this.github.inviteMember(GITHUB_ORG_NAME, user, responseHandler);
+  }
+}
+
+/// The command executed on `orgbot check <user>`
+class CheckUserCommand {
+  constructor(github) {
+    this.name = 'check';
+    this.github = github;
+  }
+
+  run(user, responseHandler) {
+    this.github.checkMembership(GITHUB_ORG_NAME, user, responseHandler);
+  }
+}
+
+/// The entry point for handling a new message.
 class MessageHandler {
   constructor(github) {
-    this.github = github;
+    this.commands = [
+      new InviteUserCommand(github),
+      new CheckUserCommand(github)
+    ];
   }
 
   handleMessage(message) {
     if (message.author.bot) return;
 
-    const messageTokens = message.content.toLowerCase().split(/ +/);
-    const orgName = 'tory-toolkit';
+    const invocation = this.extractInvocation(message.content);
 
-    if (messageTokens[0] !== 'orgbot') return;
+    if (invocation.botName !== BOT_NAME) return;
 
-    const command = messageTokens[1];
-    const user = messageTokens[2];
-
-    const isRecognisedCommand = ['check', 'invite'].includes(command);
-    if (isRecognisedCommand) {
-      if (command === 'check') {
-        if (messageTokens.length === 3) {
-          this.github.checkMembership(orgName, user, resp => {
-            message.reply(resp);
-          });
-        } else {
-          message.reply('Invalid use of `orgbot check`. Try `orgbot check <YOUR_GITHUB_USERNAME>` instead.');
-        }
-      }
-
-      if (command === 'invite') {
-        if (messageTokens.length === 3) {
-          this.github.inviteMember(orgName, user, resp => {
-            message.reply(resp);
-          });
-        } else {
-          message.reply('Invalid use of `orgbot invite`. Try `orgbot invite <YOUR_GITHUB_USERNAME>` instead.');
-        }
-      }
-    } else {
-      message.reply(`I don't understand the command \`${command}\`.`)
+    const command = this.commands.find(
+      command => command.name === invocation.commandName
+    );
+    if (!command) {
+      message.reply(
+        `I don't understand the command \`${invocation.commandName}\`.`
+      );
+      return;
     }
+
+    if (!invocation.user) {
+      message.reply(this.invalidUseError(invocation));
+      return;
+    }
+
+    command.run(invocation.user, response => {
+      message.reply(response);
+    });
+  }
+
+  extractInvocation(messageContent) {
+    const messageTokens = messageContent.toLowerCase().split(/ +/);
+    return {
+      botName: messageTokens[0],
+      commandName: messageTokens[1],
+      user: messageTokens[2]
+    };
+  }
+
+  invalidUseError(invocation) {
+    const userInvocation = `${invocation.botName} ${invocation.commandName}`;
+    return `Invalid use of \`${userInvocation}\`. Try \`${userInvocation} <YOUR_GITHUB_USERNAME>\` instead.`;
   }
 }
 

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,0 +1,42 @@
+class MessageHandler {
+  constructor(github) {
+    this.github = github;
+  }
+
+  handleMessage(message) {
+    if (message.author.bot) return;
+
+    const messageTokens = message.content.toLowerCase().split(/ +/);
+    const orgName = 'tory-toolkit';
+
+    if (!messageTokens[0] === 'orgbot') return;
+
+    const command = messageTokens[1];
+    const user = messageTokens[2];
+
+    if (command === 'check') {
+      if (messageTokens.length === 3) {
+        this.github.checkMembership(orgName, user, resp => {
+          message.reply(resp);
+        });
+      } else {
+        message.reply(`Invalid command. Try
+        \`orgbot check USERNAME \` -- check if GitHub user USERNAME is a member of the organisation`);
+      }
+    }
+
+    if (command === 'invite') {
+      if (messageTokens.length === 3) {
+        this.github.inviteMember(orgName, user, resp => {
+          message.reply(resp);
+        });
+      } else {
+        message.reply(`Invalid command. Try
+        \`orgbot invite USERNAME\` -- invite GitHub user USERNAME to the organisation`);
+      }
+    }
+  }
+
+}
+
+module.exports = MessageHandler;

--- a/test/test.message_handler.js
+++ b/test/test.message_handler.js
@@ -1,0 +1,151 @@
+const mocha = require('mocha');
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const validate = require('../src/validate');
+const MessageHandler = require('../src/message_handler');
+
+const it = mocha.it;
+const describe = mocha.describe;
+const afterEach = mocha.afterEach;
+
+describe('MessageHandler', () => {
+  const fakeGithub = {
+    checkMembership: sinon.fake(),
+    inviteMember: sinon.fake(),
+    reset: function() {
+      this.checkMembership = sinon.fake();
+      this.inviteMember = sinon.fake();
+    }
+  };
+  const messageHandler = new MessageHandler(fakeGithub);
+
+  const makeMessage = function(partialMessage) {
+    return { content: '', author: {}, reply: sinon.fake(), ...partialMessage };
+  };
+
+  afterEach(() => {
+    fakeGithub.reset();
+  });
+
+  describe('handleMessage', () => {
+    describe('when the message was sent by a bot', () => {
+      const botMessage = makeMessage({ author: { bot: {} } });
+
+      it('does not reply to the message', () => {
+        messageHandler.handleMessage(botMessage);
+        expect(botMessage.reply.called).to.equal(false);
+      });
+    });
+
+    describe('when the message is not for orgbot', () => {
+      const nonOrgbotMessage = makeMessage({
+        content: 'anotherbot check user'
+      });
+
+      it('does not reply to the message', () => {
+        messageHandler.handleMessage(nonOrgbotMessage);
+        expect(nonOrgbotMessage.reply.called).to.equal(false);
+      });
+    });
+
+    describe('when the command is not recognised', () => {
+      const badCommandMessage = makeMessage({
+        content: 'orgbot thisisinvalid'
+      });
+      const anotherBadCommandMessage = makeMessage({
+        content: 'orgbot yuuuup'
+      });
+
+      it('replies with an appropriate error message', function() {
+        messageHandler.handleMessage(badCommandMessage);
+        const expectedError = "I don't understand the command `thisisinvalid`.";
+        const args = badCommandMessage.reply.getCall(0).args;
+        expect(args[0]).to.equal(expectedError);
+      });
+
+      it('does not use a hardcoded command name in the message', () => {
+        messageHandler.handleMessage(anotherBadCommandMessage);
+        const expectedError = "I don't understand the command `yuuuup`.";
+        const args = anotherBadCommandMessage.reply.getCall(0).args;
+        expect(args[0]).to.equal(expectedError);
+      });
+    });
+
+    describe('orgbot check', () => {
+      describe('when no user is passed in', () => {
+        const checkNoUserMessage = makeMessage({ content: 'orgbot check' });
+
+        it('replies with an error message', () => {
+          messageHandler.handleMessage(checkNoUserMessage);
+          const expectedError = 'Invalid use of `orgbot check`. Try `orgbot check <YOUR_GITHUB_USERNAME>` instead.'
+          const args = checkNoUserMessage.reply.getCall(0).args;
+          expect(args[0]).to.equal(expectedError);
+        });
+      });
+
+      describe('when user tories_out is passed in', () => {
+        const validMessage = makeMessage({
+          content: 'orgbot check tories_out'
+        });
+
+        it('checks with github whether the user is part of the org', () => {
+          messageHandler.handleMessage(validMessage);
+          const args = fakeGithub.checkMembership.getCall(0).args;
+          expect(args.slice(0, 2)).to.be.deep.equal([
+            'tory-toolkit',
+            'tories_out'
+          ]);
+        });
+
+        describe('and the github check completes', () => {
+          it('replies with the response from github', () => {
+            messageHandler.handleMessage(validMessage);
+            fakeGithub.checkMembership.getCall(0).args[2]('All done');
+            const message = validMessage.reply.getCall(0).args[0];
+            expect(message).to.equal('All done');
+          });
+        });
+      });
+    });
+
+    describe('orgbot invite', () => {
+      describe('when no user is passed in', () => {
+        const inviteNoUserMessage = makeMessage({
+          content: 'orgbot invite'
+        });
+
+        it('replies with an error message', () => {
+          messageHandler.handleMessage(inviteNoUserMessage);
+          const expectedError = 'Invalid use of `orgbot invite`. Try `orgbot invite <YOUR_GITHUB_USERNAME>` instead.'
+          const args = inviteNoUserMessage.reply.getCall(0).args;
+          expect(args[0]).to.equal(expectedError);
+        });
+      });
+
+      describe('when user no-ethical-consumption is passed in', () => {
+        const validMessage = makeMessage({
+          content: 'orgbot invite no-ethical-consumption'
+        });
+
+        it('tells github to invite them to the org', () => {
+          messageHandler.handleMessage(validMessage);
+          const args = fakeGithub.inviteMember.getCall(0).args;
+          expect(args.slice(0, 2)).to.be.deep.equal([
+            'tory-toolkit',
+            'no-ethical-consumption'
+          ]);
+        });
+
+        describe('and github completes', () => {
+          it('replies with the response from github', () => {
+            messageHandler.handleMessage(validMessage);
+            fakeGithub.inviteMember.getCall(0).args[2]('Looks good');
+            const message = validMessage.reply.getCall(0).args[0];
+            expect(message).to.equal('Looks good');
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR extracts the code used to handle new messages from the Discord sdk into a `MessageHandler` class in order to write a test suite around it. 

Once the test suite was in place, I refactored `MessageHandler` to simplify it a little bit (and make it hopefully easier to add the help command, and ensure that it works for any commands added in future).

n.b. this is set up as a PR into my old branch because I'd like to merge that first so we can run unit tests on this PR - please review #3 first. That said, while it's not merged yet, here's a picture of the tests passing.

<img width="485" alt="Screenshot 2019-12-24 at 17 02 07" src="https://user-images.githubusercontent.com/13350302/71420809-3aec2000-266f-11ea-8226-17ff2f3794c5.png">
