### PR TITLE
Condar15/changes to orgbot

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const httpPort = 3838;
 const Discord = require('discord.js');
 
 const github = require('./src/github_api');
-const messageHandler = require('./src/message_handler')(github);
+const messageHandler = new (require('./src/message_handler'))(github);
 const validate = require('./src/validate');
 
 const discordToken = process.env.DISCORD_API_TOKEN;

--- a/index.js
+++ b/index.js
@@ -3,14 +3,22 @@ const httpPort = 3838;
 
 const Discord = require('discord.js');
 
-const github = require('./src/github_api');
-const messageHandler = new (require('./src/message_handler'))(github);
+const GithubApi = require('./src/github_api');
+const MessageHandler = require('./src/message_handler');
 const validate = require('./src/validate');
 
-const discordToken = process.env.DISCORD_API_TOKEN;
-const githubToken = process.env.GITHUB_API_TOKEN;
+const {
+  DISCORD_API_TOKEN: discordToken,
+  GITHUB_API_TOKEN: githubToken,
+  GITHUB_ORG_NAME: githubOrgName,
+  BOT_NAME: botName,
+} = process.env;
 
 validate.token(githubToken, discordToken);
+validate.bot(githubOrgName, botName);
+
+const github = new GithubApi(githubToken, githubOrgName);
+const messageHandler = new MessageHandler(github, botName);
 
 // Create an instance of a Discord client
 const client = new Discord.Client();

--- a/src/github_api.js
+++ b/src/github_api.js
@@ -1,56 +1,57 @@
 const Octokit = require('@octokit/rest');
 const _ = require('lodash');
 
-const octokit = new Octokit({
-  auth: process.env.GITHUB_API_TOKEN
-});
-
-const checkMembership = function(org_name, user_name, callback) {
-  octokit.orgs
-    .checkMembership({
-      org: org_name,
-      username: user_name
-    })
-    .then(({ status }) => {
-      if (status === 204) {
-        callback(`\`${user_name}\` is a member of the \`${org_name}\` organisation.`);
-      }
-    })
-    .catch(err => {
-      if (_.get(err, 'status') === 404) {
-        callback(
-          `\`${user_name}\` is not a member of the \`${org_name}\` organisation. If you would like to invite them, say \`orgbot add ${user_name}\`.`
-        );
-      }
+class GithubApi {
+  constructor(githubToken, githubOrgName) {
+    this.octokit = new Octokit({
+      auth: process.env.GITHUB_API_TOKEN
     });
-};
+    this.org_name = githubOrgName || 'tory-toolkit';
+  }
 
-const inviteMember = function(org_name, user_name, callback) {
-  octokit.orgs
-    .addOrUpdateMembership({
-      org: org_name,
-      username: user_name,
-      role: 'member'
-    })
-    .then(({ status }) => {
-      if (status === 200) {
-        callback(
-          `\`${user_name}\` has been invited to the \`${org_name}\` organisation and will receive an invitation email.`
-        );
-      }
-    })
-    .catch(err => {
-      if (_.get(err, 'status') === 403) {
-        callback(
-          'GitHub rate-limits organisation invitations particularly aggressively. Unfortunately, we have reached the limit for this period. Try again in 24 hours.'
-        );
-      } else {
-        callback('Unknown error. Try again later, or contact @daveio if the issue persists.');
-      }
-    });
-};
+  checkMembership(user_name, callback, errorCallback) {
+    this.octokit.orgs
+      .checkMembership({
+        org: this.org_name,
+        username: user_name
+      })
+      .then(({ status }) => {
+        if (status === 204) {
+          callback(`\`${user_name}\` is a member of the \`${this.org_name}\` organisation.`);
+        }
+      })
+      .catch(err => {
+        if (_.get(err, 'status') === 404) {
+          errorCallback('not-found');
+        }
+        else {
+          errorCallback('unknown');
+        }
+      });
+  }
+  
+  inviteMember(user_name, callback, errorCallback) {
+    this.octokit.orgs
+      .addOrUpdateMembership({
+        org: this.org_name,
+        username: user_name,
+        role: 'member'
+      })
+      .then(({ status }) => {
+        if (status === 200) {
+          callback(
+            `\`${user_name}\` has been invited to the \`${this.org_name}\` organisation and will receive an invitation email.`
+          );
+        }
+      })
+      .catch(err => {
+        if (_.get(err, 'status') === 403) {
+          errorCallback('rate-limited');
+        } else {
+          errorCallback('unknown');
+        }
+      });
+  }
+}
 
-module.exports = {
-  checkMembership,
-  inviteMember
-};
+module.exports = GithubApi;

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -32,6 +32,10 @@ class MessageHandler {
       new InviteUserCommand(github),
       new CheckUserCommand(github)
     ];
+
+    this.handleMessage = this.handleMessage.bind(this);
+    this.extractInvocation = this.extractInvocation.bind(this);
+    this.handleMessage = this.handleMessage.bind(this);
   }
 
   handleMessage(message) {

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,5 +1,5 @@
-const GITHUB_ORG_NAME = 'tory-toolkit';
-const BOT_NAME = 'orgbot';
+const GITHUB_ORG_NAME = process.env.GITHUB_ORG_NAME;
+const BOT_NAME = process.env.BOT_NAME;
 
 /// The command executed on `orgbot invite <user>`
 class InviteUserCommand {

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,3 +1,5 @@
+const DefaultErrorMessage = 'Unknown error. Try again later, or contact @daveio if the issue persists.';
+
 /// The command executed on `<BOT_NAME> invite <user>`
 class InviteUserCommand {
   constructor(github) {
@@ -20,7 +22,7 @@ class InviteUserCommand {
             return 'GitHub rate-limits organisation invitations particularly aggressively. Unfortunately, we have reached the limit for this period. Try again in 24 hours.';
           
             default:
-              return 'Unknown error. Try again later, or contact @daveio if the issue persists.';
+              return DefaultErrorMessage;
         }
       })
     });
@@ -49,7 +51,7 @@ class CheckUserCommand {
             return `\`${user}\` is not a member of the \`${this.github.org_name}\` organisation. If you would like to invite them, say \`${botName} invite ${user}\`.`
           
           default:
-            return 'Unknown error. Try again later, or contact @daveio if the issue persists.';
+            return DefaultErrorMessage;
         }
       })
     });

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -76,4 +76,4 @@ class MessageHandler {
   }
 }
 
-module.exports = MessageHandler;
+module.exports = github => new MessageHandler(github);

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -109,4 +109,4 @@ class MessageHandler {
   }
 }
 
-module.exports = github => new MessageHandler(github);
+module.exports = MessageHandler;

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -21,8 +21,8 @@ class InviteUserCommand {
           case 'rate-limited':
             return 'GitHub rate-limits organisation invitations particularly aggressively. Unfortunately, we have reached the limit for this period. Try again in 24 hours.';
           
-            default:
-              return DefaultErrorMessage;
+          default:
+            return DefaultErrorMessage;
         }
       })
     });

--- a/src/validate.js
+++ b/src/validate.js
@@ -9,6 +9,16 @@ const token = (githubToken, discordToken) => {
   }
 };
 
+const bot = (githubOrgName, botName) => {
+  if (githubOrgName === undefined || githubOrgName === null) {
+    console.log('GITHUB_ORG_NAME environment variable not supplied, defaulting to "tory-toolkit"');
+  }
+  if (botName === undefined || botName === null) {
+    console.log('BOT_NAME environment variable not supplied, defaulting to "orgbot"');
+  }
+}
+
 module.exports = {
-  token
+  token,
+  bot,
 };

--- a/test/test.validate.js
+++ b/test/test.validate.js
@@ -65,4 +65,43 @@ describe('validate', () => {
 
   });
 
+  describe('bot', () => {
+    let logStub;
+
+    before(() => {
+      logStub = sinon.stub(console, 'log');
+    });
+
+    after(() => {
+      console.log.restore();
+    });
+
+    afterEach(() => {
+      logStub.reset();
+    });
+
+    it('Should log a warning message when GITHUB_ORG_NAME is not set', () => {
+      const warning = 'GITHUB_ORG_NAME environment variable not supplied, defaulting to "tory-toolkit"';
+      validate.bot(null, 'bot-name');
+
+      sinon.assert.called(console.log);
+      expect(logStub.calledWith(warning)).to.equal(true);
+    })
+
+    it('Should log a warning message when BOT_NAME is not set', () => {
+      const warning = 'BOT_NAME environment variable not supplied, defaulting to "orgbot"';
+      validate.bot('org-name', null);
+
+      sinon.assert.called(console.log);
+      expect(logStub.calledWith(warning)).to.equal(true);
+    })
+
+    it('Should not log any messages when GITHUB_ORG_NAME and BOT_NAME are set', () => {
+      validate.bot('org-name', 'bot-name');
+
+      sinon.assert.notCalled(console.log);
+    })
+
+  });
+
 });


### PR DESCRIPTION
So we ended up with a larger suite of changes than I originally envisioned. The main changes introduced in this PR are:

- Fixed `TypeError`s that would cause the program to fail by adjusting the `message_handler.js` import and binding the `this` parameter in construction of `MessageHandler`
- The Github organization name and bot name are now received by environment variable (defaults to `tory-toolkit` and `orgbot` respectively), which was largely done to aid in testing of the bot in a development environment.
- Updated the `github_api.js` to now export a class that takes in an organisation name when constructed and has a new mechanism for reporting errors to be replied with
- Message command handlers have been updated to be more flexible in the command parameters they can receive
- Message command handlers have been updated to have the responsibility to construct their own error messages